### PR TITLE
Fix HintTabView; Fix RectROI

### DIFF
--- a/xicam/SAXS/SAXSGUIPlugin.py
+++ b/xicam/SAXS/SAXSGUIPlugin.py
@@ -550,8 +550,8 @@ class SAXSPlugin(GUIPlugin):
 
     def process(self, processor: XPCSProcessor, widget, **kwargs):
         if processor:
-            roiFuture = self.roiworkflow.execute(data=self.reducetabview.currentWidget().image[0],
-                                                 image=self.reducetabview.currentWidget().imageItem) # Pass in single frame for data shape
+            roiFuture = self.roiworkflow.execute(data=self.correlationView.currentWidget().image[0],
+                                                 image=self.correlationView.currentWidget().imageItem) # Pass in single frame for data shape
             roiResult = roiFuture.result()
             label = roiResult[-1]["roi"].value
             if label is None:
@@ -562,11 +562,9 @@ class SAXSPlugin(GUIPlugin):
             # FIXME -- hardcoded stream and field
             stream = "primary"
             field = "fccd_image"
-            # TODO: why do we need to invert the y axis of the label array?
-            label_invert_y = label[::-1, ::]
             # TODO: the compute() takes a long time..., do we need to do this here? If so, show a progress bar...
             data = [getattr(self.currentCatalog(), stream).to_dask()[field][0].where(
-                DataArray(label_invert_y, dims=["dim_1", "dim_2"]), drop=True).compute()]
+                DataArray(label, dims=["dim_1", "dim_2"]), drop=True).compute()]
             label = label.compress(np.any(label, axis=0), axis=1).compress(np.any(label, axis=1), axis=0)
             labels = [label] * len(data)  # TODO: update for multiple ROIs
             numLevels = [1] * len(data)

--- a/xicam/SAXS/SAXSGUIPlugin.py
+++ b/xicam/SAXS/SAXSGUIPlugin.py
@@ -562,7 +562,11 @@ class SAXSPlugin(GUIPlugin):
             # FIXME -- hardcoded stream and field
             stream = "primary"
             field = "fccd_image"
-            data = [getattr(self.currentCatalog(), stream).to_dask()[field][0].where(DataArray(label, dims=["dim_1", "dim_2"]), drop=True).compute()]
+            # TODO: why do we need to invert the y axis of the label array?
+            label_invert_y = label[::-1, ::]
+            # TODO: the compute() takes a long time..., do we need to do this here? If so, show a progress bar...
+            data = [getattr(self.currentCatalog(), stream).to_dask()[field][0].where(
+                DataArray(label_invert_y, dims=["dim_1", "dim_2"]), drop=True).compute()]
             label = label.compress(np.any(label, axis=0), axis=1).compress(np.any(label, axis=1), axis=0)
             labels = [label] * len(data)  # TODO: update for multiple ROIs
             numLevels = [1] * len(data)

--- a/xicam/SAXS/widgets/views.py
+++ b/xicam/SAXS/widgets/views.py
@@ -266,7 +266,7 @@ class HintTabView(QAbstractItemView):
                 return self._tabWidget.widget(i)
         raise IndexError
 
-    def dataChanged(self, topLeft: QModelIndex, bottomRight: QModelIndex, roles):
+    def dataChanged(self, topLeft: QModelIndex, bottomRight: QModelIndex, roles=None):
         """
         Re-implements the QAbstractItemView.dataChanged() slot.
 
@@ -283,8 +283,11 @@ class HintTabView(QAbstractItemView):
             List of roles attached to the data state change.
 
         """
+        if roles is None:
+            roles = []
         if self.model():
-            if Qt.CheckStateRole in roles:
+            # empty list indicates ALL roles have changed (see documentation)
+            if Qt.CheckStateRole in roles or len(roles) == 0:
                 hint = topLeft.data(Qt.UserRole)
                 if hint:
                     if topLeft.data(Qt.CheckStateRole) == Qt.Checked:
@@ -296,30 +299,32 @@ class HintTabView(QAbstractItemView):
                         hint.visualize(canvas)
                     else:
                         hint.remove()
+            super(HintTabView, self).dataChanged(topLeft, bottomRight, roles)
 
     def horizontalOffset(self):
-        pass
+        return 0
 
     def indexAt(self, point: QPoint):
-        pass
+        return QModelIndex()
 
     def moveCursor(self, QAbstractItemView_CursorAction, Union, Qt_KeyboardModifiers=None, Qt_KeyboardModifier=None):
         return QModelIndex()
 
     def rowsInserted(self, index: QModelIndex, start, end):
-        pass
+        return
 
     def rowsAboutToBeRemoved(self, index: QModelIndex, start, end):
-        pass
+        return
 
     def scrollTo(self, QModelIndex, hint=None):
-        pass
+        return
 
     def verticalOffset(self):
-        pass
+        return 0
 
     def visualRect(self, QModelIndex):
-        pass
+        from qtpy.QtCore import QRect
+        return QRect()
 
 
 class DerivedDataTreeView(QTreeView):


### PR DESCRIPTION
Fixes HintTabView to (default) implement the pure virtual methods for QAbstractItemView.
Fixes HintTabView.dataChanged to accept empty `roles` as *all* roles have changed.
Fixing RectROI --> https://github.com/synchrotrons/Xi-cam.gui/pull/49
